### PR TITLE
feat: 필터 프리셋 확장 및 자동 시선 정렬 개선

### DIFF
--- a/app/src/main/java/camp/visual/android/sdk/sample/domain/model/OneEuroFilterPreset.java
+++ b/app/src/main/java/camp/visual/android/sdk/sample/domain/model/OneEuroFilterPreset.java
@@ -2,10 +2,11 @@ package camp.visual.android.sdk.sample.domain.model;
 
 public enum OneEuroFilterPreset {
     STABILITY("안정성 우선", "매우 부드럽고 안정적, 떨림 최소화", 30.0, 0.5, 0.0, 1.0),
-    BALANCED("균형", "안정성과 반응성의 균형 (권장)", 30.0, 1.0, 0.0, 1.0),
-    RESPONSIVE("반응성 우선", "빠른 반응, 약간의 떨림 허용", 30.0, 1.5, 0.1, 1.0),
-    HIGH_RESPONSIVE("고반응성", "매우 빠른 반응, 떨림 더 많이 허용", 30.0, 2.0, 0.2, 1.0),
-    CUSTOM("커스텀", "사용자 직접 설정", 30.0, 1.0, 0.0, 1.0);
+    BALANCED_STABILITY("균형-안정성", "안정성을 조금 더 중시", 30.0, 0.75, 0.003, 1.0),
+    BALANCED("균형 (권장)", "안정성과 반응성의 균형", 30.0, 1.0, 0.007, 1.0),
+    BALANCED_RESPONSIVE("균형-반응성", "반응성을 조금 더 중시", 30.0, 1.25, 0.01, 1.0),
+    RESPONSIVE("반응성 우선", "빠른 반응, 약간의 떨림 허용", 30.0, 1.5, 0.015, 1.0),
+    CUSTOM("커스텀", "사용자 직접 설정", 30.0, 1.0, 0.007, 1.0);
 
     private final String displayName;
     private final String description;

--- a/app/src/main/java/camp/visual/android/sdk/sample/domain/model/UserSettings.java
+++ b/app/src/main/java/camp/visual/android/sdk/sample/domain/model/UserSettings.java
@@ -144,11 +144,11 @@ public class UserSettings {
         private float cursorOffsetX = 0f;
         private float cursorOffsetY = 0f;
 
-        // OneEuroFilter 기본값 - 균형 프리셋
+        // OneEuroFilter 기본값 - 균형 프리셋 (사진의 기본값과 일치)
         private OneEuroFilterPreset oneEuroFilterPreset = OneEuroFilterPreset.BALANCED;
         private double oneEuroFreq = 30.0;
         private double oneEuroMinCutoff = 1.0;
-        private double oneEuroBeta = 0.0;
+        private double oneEuroBeta = 0.007;  // 사진의 기본값으로 변경
         private double oneEuroDCutoff = 1.0;
 
         public Builder() {}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -17,14 +17,26 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent">
 
-    <!-- 캘리브레이션 버튼만 남김 -->
+    <!-- 정렬 버튼 추가 -->
+    <Button
+        android:id="@+id/btn_alignment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="정렬"
+        android:textSize="16sp"
+        android:padding="12dp"
+        android:backgroundTint="#4CAF50"
+        android:textColor="@android:color/white" />
+
+    <!-- 정밀 캘리브레이션 버튼 -->
     <Button
         android:id="@+id/btn_start_calibration"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="캘리브레이션 시작"
+        android:text="정밀 보정"
         android:textSize="16sp"
-        android:padding="12dp" />
+        android:padding="12dp"
+        android:layout_marginTop="8dp" />
 
     <!-- 설정 버튼 -->
     <Button

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -144,6 +144,21 @@
                 android:layout_marginBottom="8dp"/>
 
             <RadioButton
+                android:id="@+id/radio_balanced_stability"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="🔍 균형-안정성"
+                android:layout_marginBottom="4dp"/>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="   안정성을 조금 더 중시"
+                android:textSize="12sp"
+                android:textColor="#666666"
+                android:layout_marginBottom="8dp"/>
+
+            <RadioButton
                 android:id="@+id/radio_balanced"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -159,6 +174,21 @@
                 android:layout_marginBottom="8dp"/>
 
             <RadioButton
+                android:id="@+id/radio_balanced_responsive"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="🔸 균형-반응성"
+                android:layout_marginBottom="4dp"/>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="   반응성을 조금 더 중시"
+                android:textSize="12sp"
+                android:textColor="#666666"
+                android:layout_marginBottom="8dp"/>
+
+            <RadioButton
                 android:id="@+id/radio_responsive"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -169,21 +199,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="   빠른 반응, 약간의 떨림 허용"
-                android:textSize="12sp"
-                android:textColor="#666666"
-                android:layout_marginBottom="8dp"/>
-
-            <RadioButton
-                android:id="@+id/radio_high_responsive"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="🚀 고반응성"
-                android:layout_marginBottom="4dp"/>
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="   매우 빠른 반응, 떨림 더 많이 허용"
                 android:textSize="12sp"
                 android:textColor="#666666"
                 android:layout_marginBottom="8dp"/>
@@ -301,14 +316,14 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:max="20"
-                    android:progress="0"/>
+                    android:max="50"
+                    android:progress="7"/>
 
                 <TextView
                     android:id="@+id/text_one_euro_beta"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="0.0"
+                    android:text="0.007"
                     android:layout_marginStart="8dp"
                     android:minWidth="70dp"/>
             </LinearLayout>


### PR DESCRIPTION
- OneEuroFilter 프리셋을 5단계로 확장 (안정성→균형-안정성→균형→균형-반응성→반응성)
- 균형 프리셋 beta 값을 0.007로 조정 (SDK 기본값과 일치)
- 앱 시작 시 커서 오프셋 자동 초기화 기능 추가
- 자동 캘리브레이션을 즉시 시작하도록 변경 (3초 대기 제거)
- 캘리브레이션 안내 화면 시간 1초 연장 (1초→2초)
- '정렬' 버튼 추가로 원포인트 캘리브레이션 수동 실행 지원
- 설정 화면에서 실시간 오프셋 값 표시 개선

사용자 경험: 앱 실행 즉시 자동 정렬 → 필요시 '정렬' 버튼으로 재정렬 → '정밀 보정' 버튼으로 5포인트 캘리브레이션